### PR TITLE
Handle using declarations declared with macros

### DIFF
--- a/clang_delta/RemoveUnusedFunction.cpp
+++ b/clang_delta/RemoveUnusedFunction.cpp
@@ -649,7 +649,13 @@ void RemoveUnusedFunction::removeOneFunctionDeclGroup(const FunctionDecl *FD)
     const FunctionDecl *ParentFD = UsingParentFDs[(*I).first];
     if (ParentFD && RemovedFDs.count(ParentFD->getCanonicalDecl()))
       continue;
-    RewriteHelper->removeDecl((*I).first);
+    const UsingDecl *UD = (*I).first;
+    SourceRange Range = UD->getSourceRange();
+    if (Range.getBegin().isMacroID()) {
+      TheRewriter.RemoveText(SrcManager->getExpansionRange(Range));
+    } else {
+      RewriteHelper->removeDecl((*I).first);
+    }
   }
 }
 

--- a/clang_delta/tests/remove-unused-function/macro_using.cc
+++ b/clang_delta/tests/remove-unused-function/macro_using.cc
@@ -1,0 +1,8 @@
+// RUN: %clang_delta --transformation=remove-unused-function --counter=1 %s 2>&1 | %remove_lit_checks | FileCheck %s
+
+// CHECK: #define USING using ::foo;
+#define USING using ::foo;
+// CHECK-NOT: void foo
+void foo();
+// CHECK-NOT: USING 
+USING


### PR DESCRIPTION
In such cases, we should remove the macro expansions instead